### PR TITLE
Corrects 'glusterfs_device' to become 'glusterfs_devices' (plural)

### DIFF
--- a/openshift_cic/templates/310/app.j2
+++ b/openshift_cic/templates/310/app.j2
@@ -20,5 +20,5 @@ openshift_storage_glusterfs_block_deploy=false
    
 [glusterfs]
 {% for app in app_hosts -%}
-	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ raw_devices }}'
+	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ raw_devices }}'
 {% endfor -%}

--- a/openshift_cic/templates/310/applog-multi.j2
+++ b/openshift_cic/templates/310/applog-multi.j2
@@ -48,10 +48,10 @@ openshift_storage_glusterfs_registry_block_storageclass_default=false
    
 [glusterfs]
 {% for app in app_hosts -%}
-	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ raw_devices }}'
+	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ raw_devices }}'
 {% endfor %}
 
 [glusterfs_registry]
 {% for z in log_hosts -%}
-	{{z}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ log_devices }}'
+	{{z}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ log_devices }}'
 {% endfor -%}

--- a/openshift_cic/templates/310/applog.j2
+++ b/openshift_cic/templates/310/applog.j2
@@ -38,5 +38,5 @@ openshift_storage_glusterfs_block_storageclass_default=false
 
 [glusterfs]
 {% for app in app_hosts -%}
-	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ raw_devices }}'
+	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device=s'{{ raw_devices }}'
 {% endfor -%}

--- a/openshift_cic/templates/310/applogmet-multi.j2
+++ b/openshift_cic/templates/310/applogmet-multi.j2
@@ -57,10 +57,10 @@ openshift_storage_glusterfs_registry_block_storageclass_default=false
    
 [glusterfs]
 {% for app in app_hosts -%}
-	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ raw_devices }}'
+	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ raw_devices }}'
 {% endfor %}
 
 [glusterfs_registry]
 {% for z in met_log_hosts -%}
-	{{z}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ met_log_devices }}'
+	{{z}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ met_log_devices }}'
 {% endfor -%}

--- a/openshift_cic/templates/310/appmet-multi.j2
+++ b/openshift_cic/templates/310/appmet-multi.j2
@@ -47,10 +47,10 @@ openshift_storage_glusterfs_registry_block_storageclass_default=false
    
 [glusterfs]
 {% for app in app_hosts -%}
-	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ raw_devices }}'
+	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ raw_devices }}'
 {% endfor %}
 
 [glusterfs_registry]
 {% for z in met_hosts -%}
-	{{z}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ met_devices }}'
+	{{z}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ met_devices }}'
 {% endfor -%}

--- a/openshift_cic/templates/310/appmet.j2
+++ b/openshift_cic/templates/310/appmet.j2
@@ -38,6 +38,6 @@ openshift_storage_glusterfs_block_storageclass_default=false
 
 [glusterfs]
 {% for app in app_hosts -%}
-	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ raw_devices }}'
+	{{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ raw_devices }}'
 {% endfor -%}
 

--- a/openshift_cic/templates/310/appreg.j2
+++ b/openshift_cic/templates/310/appreg.j2
@@ -25,6 +25,6 @@ openshift_storage_glusterfs_block_deploy=false
    
 [glusterfs]
 {% for app in app_hosts -%}
-        {{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_device='{{ raw_devices }}'
+        {{app}} glusterfs_zone={{loop.cycle(1,2,3)}}  glusterfs_devices='{{ raw_devices }}'
 {% endfor -%}
 


### PR DESCRIPTION
OpenShift 3.10 requires `glusterfs_devices` plural and doesn't accept `glusterfs_device` singular. 

Don't recall if 3.9 accepts singular instead of plural so leaving as is.